### PR TITLE
webstat: drop v1 from REST URL

### DIFF
--- a/get_webstat_metrics.py
+++ b/get_webstat_metrics.py
@@ -90,10 +90,10 @@ async def main():
         },
         "gateways": {
             "mainnet": [
-                ["https://http.fs.neo.org", "https://rest.fs.neo.org/v1"],
+                ["https://http.fs.neo.org", "https://rest.fs.neo.org/"],
             ],
             "testnet": [
-                ["https://http.t5.fs.neo.org", "https://rest.t5.fs.neo.org/v1"],
+                ["https://http.t5.fs.neo.org", "https://rest.t5.fs.neo.org/"],
             ],
         },
         "side_chain_rpc_nodes": {


### PR DESCRIPTION
We have a redirect to documentation now (since gw 0.7.0).